### PR TITLE
CRF Update data formatting options

### DIFF
--- a/src/2prioritization.R
+++ b/src/2prioritization.R
@@ -119,6 +119,12 @@ if(class(scenarioSolution) == "data.frame"){
 
 # Save inputs ------------------------------------------------------------------
 
+# Load datasheets
+inputDatasheet <- datasheet(myScenario,
+                            name = "prioritizr_inputData")
+optionsDatasheet <- datasheet(myScenario,
+                            name = "prioritizr_preprocessOptions")
+
 # Check which inputs need mapping
 mapInputsDatasheet <- datasheet(myScenario,
                                 name = "prioritizr_mapInputs")
@@ -306,14 +312,33 @@ if(dim(mapInputsDatasheet)[1] !=0 & any(mapInputsDatasheet[1,], na.rm = TRUE)){
           
           # Get feature ID
           featureID <- featuresDatasheet$featureID[j]
+          featureName <- featuresDatasheet$variableName[j]
           
-          # Subset rij table to get reclass table of planning unit ID to value
-          reclassTable <- as.matrix(rij[rij$species == featureID,c(1,3)])
-          
+          # If input data was scaled and/or inverting, map original values.
+          # Otherwise, use rij matrix.
+          if (isTRUE((optionsDatasheet$scaleData)) | 
+                !is.null(optionsDatasheet$invertData)) {
+
+                  # Read data
+                  inputData <- read.csv(
+                    inputDatasheet$tabularProblem, header = TRUE
+                    )
+
+                  # Build reclass table of planning unit ID to value
+                  reclassTable <- as.matrix(
+                    cbind(inputData$id, inputData[,featureName])
+                    )
+                    cat("here")
+
+          } else {
+            # Subset rij table to get reclass table of planning unit ID to value
+            reclassTable <- as.matrix(rij[rij$species == featureID,c(1,3)])
+          }
+            
           # Reclassify raster
           rasterVis <- classify(pu_vis, reclassTable)
-          #plot(rasterVis)    
-          
+          #plot(rasterVis)  
+
           # Define file path
           rasterVisFilename <- file.path(paste0(
             featureVisFilepath, paste0("\\feature", featureID, ".tif")))

--- a/src/2prioritization.R
+++ b/src/2prioritization.R
@@ -328,8 +328,6 @@ if(dim(mapInputsDatasheet)[1] !=0 & any(mapInputsDatasheet[1,], na.rm = TRUE)){
                   reclassTable <- as.matrix(
                     cbind(inputData$id, inputData[,featureName])
                     )
-                    cat("here")
-
           } else {
             # Subset rij table to get reclass table of planning unit ID to value
             reclassTable <- as.matrix(rij[rij$species == featureID,c(1,3)])

--- a/src/2prioritization.R
+++ b/src/2prioritization.R
@@ -302,6 +302,11 @@ if(dim(mapInputsDatasheet)[1] !=0 & any(mapInputsDatasheet[1,], na.rm = TRUE)){
         ifelse(!dir.exists(file.path(featureVisFilepath)), 
                dir.create(file.path(featureVisFilepath)), FALSE)
         
+        # Read data
+        inputData <- read.csv(
+          inputDatasheet$tabularProblem, header = TRUE
+        )
+
         # Read datasheet
         featureRasterOutputDatasheet <- data.frame(
           projectFeaturesId = as.character(),
@@ -317,12 +322,7 @@ if(dim(mapInputsDatasheet)[1] !=0 & any(mapInputsDatasheet[1,], na.rm = TRUE)){
           # If input data was scaled and/or inverting, map original values.
           # Otherwise, use rij matrix.
           if (isTRUE((optionsDatasheet$scaleData)) | 
-                !is.null(optionsDatasheet$invertData)) {
-
-                  # Read data
-                  inputData <- read.csv(
-                    inputDatasheet$tabularProblem, header = TRUE
-                    )
+                !is.na(optionsDatasheet$invertData)) {
 
                   # Build reclass table of planning unit ID to value
                   reclassTable <- as.matrix(

--- a/src/3evaluatePerformance.R
+++ b/src/3evaluatePerformance.R
@@ -92,7 +92,7 @@ if(isTRUE(performanceDatasheet$eval_feature_representation_summary)){
     # If input data was scaled and/or inverting, use original values.
     # Otherwise, use prioritizr function.
     if (isTRUE((optionsDatasheet$scaleData)) | 
-          !is.null(optionsDatasheet$invertData)) {
+          !is.na(optionsDatasheet$invertData)) {
       
       # Read data
       inputData <- read.csv(
@@ -169,7 +169,7 @@ if(isTRUE(performanceDatasheet$eval_target_coverage_summary)){
     # If input data was scaled and/or inverting, use original values.
     # Otherwise, use prioritizr function.
     if (isTRUE((optionsDatasheet$scaleData)) | 
-          !is.null(optionsDatasheet$invertData) & 
+          !is.na(optionsDatasheet$invertData) & 
           targetDatasheet$addTarget == "Relative") {
       
       # Read data

--- a/src/3evaluatePerformance.R
+++ b/src/3evaluatePerformance.R
@@ -168,8 +168,8 @@ if(isTRUE(performanceDatasheet$eval_target_coverage_summary)){
 
     # If input data was scaled and/or inverting, use original values.
     # Otherwise, use prioritizr function.
-    if (isTRUE((optionsDatasheet$scaleData)) | 
-          !is.na(optionsDatasheet$invertData) & 
+    if ((isTRUE((optionsDatasheet$scaleData)) | 
+          !is.na(optionsDatasheet$invertData)) & 
           targetDatasheet$addTarget == "Relative") {
       
       # Read data

--- a/src/3evaluatePerformance.R
+++ b/src/3evaluatePerformance.R
@@ -75,15 +75,74 @@ if(isTRUE(performanceDatasheet$eval_cost_summary)){
                 name = "prioritizr_costOutput")
 }
 
+# Load datasheets
+  inputDatasheet <- datasheet(myScenario,
+                              name = "prioritizr_inputData")
+  optionsDatasheet <- datasheet(myScenario,
+                                name = "prioritizr_preprocessOptions")
+
 # Calculate how well features are represented by a solution
 if(isTRUE(performanceDatasheet$eval_feature_representation_summary)){
-  
+
   if(class(scenarioSolution) != "data.frame"){
     featureRepresentation <- eval_feature_representation_summary(
       scenarioProblem, scenarioSolution) }
   if(class(scenarioSolution) == "data.frame"){
-    featureRepresentation <- eval_feature_representation_summary(
-      scenarioProblem, scenarioSolution[,"solution_1", drop = FALSE]) }
+    
+    # If input data was scaled and/or inverting, use original values.
+    # Otherwise, use prioritizr function.
+    if (isTRUE((optionsDatasheet$scaleData)) | 
+          !is.null(optionsDatasheet$invertData)) {
+      
+      # Read data
+      inputData <- read.csv(
+        inputDatasheet$tabularProblem, header = TRUE
+      )
+
+      # Create empty dataframe for results
+      featureRepresentation <- data.frame(
+        summary = as.character(),
+        feature = as.character(),
+        total_amount = as.numeric(),
+        absolute_held = as.numeric(),
+        relative_held = as.numeric()
+      )
+
+      for(j in 1:length(featuresDatasheet$variableName)){
+          
+        # Get feature ID
+        featureName <- featuresDatasheet$variableName[j]
+        
+        # Get solution
+        solution <- scenarioSolution[,"solution_1", drop = FALSE]
+
+        # Total amount of each feature
+        totalFeature <- sum(inputData[,featureName])
+        # Amount of each feature held in the solution
+        heldFeature <- sum(inputData[solution$solution_1 == 1, featureName])
+        # Relative amount
+        relativeFeature <- heldFeature/totalFeature
+
+        # Build dataframe
+        featureRepresentationTemp <- data.frame(
+          summary = "overall",
+          feature = featureName,
+          total_amount = totalFeature,
+          absolute_held = heldFeature,
+          relative_held = relativeFeature
+        )
+              
+        # Combine dataframes
+        featureRepresentation <- rbind(
+          featureRepresentation,
+          featureRepresentationTemp
+        )
+      }
+    } else {
+      featureRepresentation <- eval_feature_representation_summary(
+      scenarioProblem, scenarioSolution[,"solution_1", drop = FALSE])
+    }
+  }
   
   # Save results
   names(featureRepresentation)[2] <- "projectFeaturesId"
@@ -100,12 +159,93 @@ if(isTRUE(performanceDatasheet$eval_feature_representation_summary)){
 
 # Calculate how well the targets are met by the solution
 if(isTRUE(performanceDatasheet$eval_target_coverage_summary)){
+  
   if(class(scenarioSolution) != "data.frame"){
     targetCoverage <- eval_target_coverage_summary(scenarioProblem, 
                                                    scenarioSolution) }
+  
   if(class(scenarioSolution) == "data.frame"){
+
+    # If input data was scaled and/or inverting, use original values.
+    # Otherwise, use prioritizr function.
+    if (isTRUE((optionsDatasheet$scaleData)) | 
+          !is.null(optionsDatasheet$invertData)) {
+      
+      # Read data
+      inputData <- read.csv(
+        inputDatasheet$tabularProblem, header = TRUE
+      )
+
+      # Get target
+      targetDatasheet <- datasheet(myScenario, name = "prioritizr_targets")
+
+      if (targetDatasheet$addTarget == "Relative") {
+
+        # Create empty dataframe for results
+        targetCoverage <- data.frame(
+          feature = as.character(),
+          met = as.character(),
+          total_amount = as.numeric(),
+          absolute_target = as.numeric(),
+          absolute_held = as.numeric(),
+          absolute_shortfall = as.numeric(),
+          relative_target = as.numeric(),
+          relative_held = as.numeric(),
+          relative_shortfall = as.numeric()
+        )
+
+        for(j in 1:length(featuresDatasheet$variableName)){
+
+          # Get feature name
+          featureName <- featuresDatasheet$variableName[j]
+          # Get feature ID
+          featureID <- featuresDatasheet$featureID[j]
+          
+          # Get solution
+          solution <- scenarioSolution[,"solution_1", drop = FALSE]
+
+          # Total amount of each feature
+          totalFeature <- sum(inputData[,featureName])
+          # Target amount of each feature
+          targetFeature <- totalFeature * targetDatasheet$targets
+          # Amount of each feature held in the solution
+          heldFeature <- sum(inputData[solution$solution_1 == 1, featureName])
+          # Relative amount of each feature held in the solution
+          relativeHeld <- heldFeature / totalFeature
+          
+          # Target absolute shortfall
+          absoluteShortfall <- targetFeature - heldFeature
+          # Target relative shortfall
+          relativeShortfall <- targetDatasheet$targets - relativeHeld
+                 
+          # Check if target was met or not
+          targetMet <- (heldFeature >= targetFeature)
+
+          # Build dataframe
+          targetCoverageTemp <- data.frame(
+            feature = featureName,
+            met = targetMet,
+            total_amount = totalFeature,
+            absolute_target = targetFeature,
+            absolute_held = heldFeature,
+            absolute_shortfall = absoluteShortfall,
+            relative_target = targetDatasheet$targets,
+            relative_held = relativeHeld,
+            relative_shortfall = relativeShortfall
+          )
+                
+          # Combine dataframes
+          targetCoverage <- rbind(
+            targetCoverage,
+            targetCoverageTemp
+          )
+        }
+      }
+    } else {
     targetCoverage <- eval_target_coverage_summary(
-      scenarioProblem, scenarioSolution[,"solution_1", drop = FALSE]) }
+      scenarioProblem, scenarioSolution[,"solution_1", drop = FALSE]) 
+    }
+  }
   
   # Save results
   names(targetCoverage)[1] <- "projectFeaturesId"
@@ -122,7 +262,7 @@ if(isTRUE(performanceDatasheet$eval_target_coverage_summary)){
                 name = "prioritizr_targetCoverageOutput") 
 }
 
-# Calculate solution the total exposed boundary length (perimeter)
+# Calculate the solution total exposed boundary length (perimeter)
 if(isTRUE(performanceDatasheet$eval_boundary_summary)){
   
   if(class(scenarioSolution) != "data.frame"){

--- a/src/package.xml
+++ b/src/package.xml
@@ -47,6 +47,12 @@
     <column name="costData" displayName="Multi-cost input" dataType="String" isExternalFile="True" />
   </dataSheet>
 
+  <dataSheet name="preprocessOptions" displayName="Options" isSingleRow="True">
+    <column name="scaleData" displayName="Scale features" dataType="Boolean" />
+    <column name="invertData" displayName="Features to invert" dataType="String" isExternalFile="True" />
+    <record columns="scaleData" values="-1"/>
+  </dataSheet>
+
   <dataSheet name="problemTabularPU" displayName="Planning Units" isSingleRow="False">
     <column name="id" displayName="Planning Unit ID" dataType="Integer" validationType="WholeNumber" validationCondition="GreaterEqual" formula1="1" />
     <column name="Name" displayName="Planning Unit Name" dataType="String" validationType="String" />
@@ -575,6 +581,7 @@
   condaEnv="prioritizrEnv.yml"
   condaEnvVersion="4">
       <dataSheet name="inputData" type="Input" />
+      <dataSheet name="preprocessOptions" type="Input" />
       <dataSheet name="problemTabularPU" type="Output" />
       <dataSheet name="problemTabularFeatures" type="Output" />
       <dataSheet name="problemTabularPUvsFeatures" type="Output" />
@@ -590,6 +597,7 @@
   <layout type="Scenario"> 
     <group name="Data0Formatting" displayName="Data Formatting">
       <item name="inputData" />
+      <item name="preprocessOptions" />
     </group >
     <group name="Base0Prioritization" displayName="Base Prioritization">
       <group name="Data" displayName="Data">

--- a/src/package.xml
+++ b/src/package.xml
@@ -477,6 +477,8 @@
     <dataSheet name="featureRasterOutput" type="Output" />
     <dataSheet name="inputRasterOutput" type="Output" />
     <dataSheet name="mapInputs" type="Input" />
+    <dataSheet name="inputData" type="Input" />
+    <dataSheet name="preprocessOptions" type="Input" />  
   </transformer>
 
   <transformer 

--- a/src/preProcessing.R
+++ b/src/preProcessing.R
@@ -44,10 +44,10 @@ scale_feature <- function(featureVector){
   minValue <- min(featureVector)
 
   if (maxValue == minValue) {
-    return(rep(0, length(featureVector)))
     updateRunLog("At least one feature variable had identical values across 
     planning units. During the scaling process, all zero values were returned.",
     type = "warning")
+    return(rep(0, length(featureVector)))
   }
   
   # Scale data from 0 to 1

--- a/src/preProcessing.R
+++ b/src/preProcessing.R
@@ -42,6 +42,13 @@ scale_feature <- function(featureVector){
   # Get minimum and maximum value across all features
   maxValue <- max(featureVector)
   minValue <- min(featureVector)
+
+  if (maxValue == minValue) {
+    return(rep(0, length(featureVector)))
+    updateRunLog("At least one feature variable had identical values across 
+    planning units. During the scaling process, all zero values were returned.",
+    type = "warning")
+  }
   
   # Scale data from 0 to 1
   scaled_feature <- (featureVector - minValue) / (maxValue - minValue)
@@ -82,20 +89,27 @@ if(length(inputDatasheet$tabularProblem) != 0){
       for(i in 5:(numberFeatures+4)){
         inputData[,i] <- scale_feature(inputData[,i, drop = TRUE])
       }
-    }
-    
-    # Check is feature variables need to be inverted
-    if (!is.null(optionsDatasheet$invertData)) {
+
+      # Check is feature variables also needs to be inverted
+      if (!is.na(optionsDatasheet$invertData)) {
       
-      # Open list of feature variables to invert
-      toInvert <- as.vector(
-        read.csv(optionsDatasheet$invertData, header = FALSE)[,1]
-        )
+        # Open list of feature variables to invert
+        toInvert <- as.vector(
+          read.csv(optionsDatasheet$invertData, header = FALSE)[,1]
+          )
       
-      # Reverse scale
-      for(i in toInvert){
-        inputData[,i] <- reverse_scale(inputData[,i, drop = TRUE])
+        # Reverse scale
+        for(invertName in toInvert){
+          inputData[,invertName] <- reverse_scale(inputData[,invertName, drop = TRUE])
+        }
       }
+    }
+
+    if (!isTRUE(optionsDatasheet$scaleData) & !is.na(optionsDatasheet$invertData)) {
+      updateRunLog(
+      "Feature variables can only be inverted if they are scaled first.",
+      type = "warning"
+      )
     }
     
     # Planning units vs. Features

--- a/src/updates/update-3.1.xml
+++ b/src/updates/update-3.1.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<update comment="Update to prioritizr 3.0 adding pre-processing option to data formatting datasheet">
+
+</update>

--- a/src/updates/update-3.1.xml
+++ b/src/updates/update-3.1.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<update comment="Update to prioritizr 3.0 adding pre-processing option to data formatting datasheet">
+<update comment="Update from prioritizr 3.0 to 3.1 adding pre-processing option to data formatting datasheet">
 
 </update>


### PR DESCRIPTION
- Add new datasheet with scaling and inverting options
- Add process for scaling and inverting raw data
- If raw data was scaled and/or inverted, feature input maps, feature representation, and target representation should be based on original data (i.e., prior to scaling and/or inverting)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added preprocessing options to normalize features and list features to invert; exposed in Data Formatting and Scenario views.

* **Improvements**
  * Prioritization and performance evaluation now honour scaling/inversion settings, computing per-feature totals, targets and coverage from original values when needed.
  * Data preparation applies conditional scaling/inversion and warns if inversion is requested without prior scaling.

* **Updates**
  * Added migration/update entry for the new preprocessing option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->